### PR TITLE
Update stores_info.csv

### DIFF
--- a/stores_info.csv
+++ b/stores_info.csv
@@ -6,29 +6,23 @@ Walmart,"Southpark Meadows, 9300 S Interstate 35",Austin,TX,78748,-97.792074,30.
 Walmart,"Svc Rd Sb, 12900 N Interstate Hwy 35",Austin,TX,78753,-97.671089,30.388987
 Walmart,2525 W Anderson Ln,Austin,TX,78757,-97.733298,30.355196
 Walmart,13201 Ranch Rd 620 N,Austin,TX,78717,-97.791632,30.468023
-Walmart,2701 S Interstate 35,Round Rock,TX,78664,-97.669832,30.483073
 Walmart,8201 N FM 620,Austin,TX,78726,-97.8452263,30.4164823
-Walmart,690 Old San Antonio Rd,Buda,TX,78610,-97.825035,30.086646
-Costco,4601 TX-183A Toll Rd,Cedar Park,TX,78613,-97.8190231,30.527228
 Costco,10401 Research Blvd,Austin,TX,78759,-97.743585,30.3967472
 Costco,4301 W William Cannon Dr,South Austin,TX,78749,-97.8416446,30.219648
 Sam's Club,"Southpark Meadows, J-34, 9900 S IH 35 Frontage Rd",Austin,TX,78748,-97.7968351,30.1560748
 Sam's Club,"South Town Square, 4970 W Hwy 290",Austin,TX,78735,-97.8207358,30.236365
 Sam's Club,"Gateway Shopping Centers, 9700 N Capital of Texas Hwy",Austin,TX,78759,-97.742778,30.391767
 Sam's Club,10901 Lakeline Mall Dr,Austin,TX,78717,-97.794982,30.472862
-Sam's Club,"La Frontera Village, 130 Sundance Pkwy #300",Round Rock,TX,78681,-97.680925,30.485391
 Big Lots,8666 Spicewood Springs Rd,Austin,TX,78759,-97.7716568,30.4329963
-Big Lots,850 N Bell Blvd #104,Cedar Park,TX,78613,-97.8297692,30.5198247
-Big Lots,"Mays Crossing Shopping Center, 1201 S Interstate 35 #200",Round Rock,TX,78664,-97.6809919,30.5003103
 Big Lots,8740 Research Blvd,Austin,TX,78757,-97.7216924,30.3647411
-Big Lots,7101 W Hwy 71 Ste D1,Austin,TX,78735,-97.8796896,30.2346999
+Big Lots,7101 W SH 71,Austin,TX,78735,-97.8796896,30.2346999
 Big Lots,"Parmer Crossing, 2506 W Parmer Ln",Austin,TX,78727,-97.7032259,30.4204453
 Target,2300 W Ben White Blvd,Austin,TX,78704,-97.7937676,30.2334435
-Target ,8601 Research Blvd,Austin,TX,78758,-97.7176078,30.3627666
-Target ,"Capital Plaza Shopping Center, 5621 N I H 35",Austin,TX,78723,-97.7085014,30.3146364
-Target ,10107 Research Blvd,Austin,TX,78759,-97.746154,30.3927847
+Target,8601 Research Blvd,Austin,TX,78758,-97.7176078,30.3627666
+Target,"Capital Plaza Shopping Center, 5621 N I H 35",Austin,TX,78723,-97.7085014,30.3146364
+Target,10107 Research Blvd,Austin,TX,78759,-97.746154,30.3927847
 Target,5300 S MoPac Expy,Austin,TX,78749,-97.8300194,30.2337365
 Target,10900 Lakeline Mall Dr,Austin,TX,78717,-97.7986616,30.4763797
-Target,12901 N Interstate Hwy 35 #3,Austin,TX,78753,-97.669946,30.415144
+Target,12901 N IF 35 NB,Austin,TX,78753,-97.669946,30.415144
 Target,"Southpark Meadows, 9500 S IH 35 Frontage Rd",Austin,TX,78748,-97.792024,30.161056
 Target,11220 FM 2222,Austin,TX,78730,-97.929487,30.174665


### PR DESCRIPTION
I looked into the stores that had 0 crimes. Most of them were located in different cities, and I confirmed that those cities have their own police departments. There were 2 others that do seem to match up to our crime list, but the address was far enough off that the code wasn't picking it up. For this set, 100% have crimes associated with them. I'm going to also take a look at some of the ones that have really low numbers to see if they might have different forms of the addresses that we're not picking up.
